### PR TITLE
Support half open connection to ensure fd release as soon as tcp closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # idea
 .idea
+/bin

--- a/block/block.go
+++ b/block/block.go
@@ -2,14 +2,19 @@ package block
 
 import (
 	"encoding/binary"
-	"go.uber.org/atomic"
 	"io"
+
+	"go.uber.org/atomic"
 )
 
 const (
 	TypeConnect = iota
 	TypeDisconnect
 	TypeData
+
+	ShutdownRead = iota
+	ShutdownWrite
+	ShutdownBoth
 
 	HeaderSize = 1 + 4 + 4 + 4
 	DataSize   = 16*1024 - 13
@@ -96,12 +101,12 @@ func NewDataBlocks(connectID uint32, blockID *atomic.Uint32, data []byte) []Bloc
 	return blocks
 }
 
-func NewDisconnectBlock(connectID uint32, blockID uint32) Block {
+func NewDisconnectBlock(connectID uint32, blockID uint32, shutdownType uint8) Block {
 	return Block{
 		Type:         TypeDisconnect,
 		ConnectionID: connectID,
 		BlockID:      blockID,
-		BlockLength:  0,
-		BlockData:    make([]byte, 0),
+		BlockLength:  1,
+		BlockData:    []byte{shutdownType},
 	}
 }

--- a/connection/block_processor.go
+++ b/connection/block_processor.go
@@ -2,10 +2,11 @@ package connection
 
 import (
 	"context"
+	"time"
+
 	"github.com/ihciah/rabbit-tcp/block"
 	"github.com/ihciah/rabbit-tcp/logger"
 	"go.uber.org/atomic"
-	"time"
 )
 
 // 1. Join blocks from chan to connection orderedRecvQueue
@@ -69,7 +70,7 @@ func (x *blockProcessor) OrderedRelay(connection Connection) {
 		case <-time.After(PacketWaitTimeoutSec * time.Second):
 			x.logger.Debugf("Packet wait time exceed of Connection %d.\n", connection.GetConnectionID())
 			if x.recvBlockID == x.lastRecvBlockID {
-				x.logger.Debugf("Connection %d is not in waiting status, continue.\n", connection.GetConnectionID())
+				x.logger.Debugf("recvBlockId == lastRecvBlockID(%d), but Connection %d is not in waiting status, continue.\n", x.recvBlockID, connection.GetConnectionID())
 				continue
 			}
 			x.logger.Warnf("Connection %d is going to be killed due to timeout.\n", connection.GetConnectionID())
@@ -89,6 +90,6 @@ func (x *blockProcessor) packConnect(address string, connectionID uint32) block.
 	return block.NewConnectBlock(connectionID, x.sendBlockID.Inc()-1, address)
 }
 
-func (x *blockProcessor) packDisconnect(connectionID uint32) block.Block {
-	return block.NewDisconnectBlock(connectionID, x.sendBlockID.Inc()-1)
+func (x *blockProcessor) packDisconnect(connectionID uint32, shutdownType uint8) block.Block {
+	return block.NewDisconnectBlock(connectionID, x.sendBlockID.Inc()-1, shutdownType)
 }

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -48,6 +48,7 @@ type baseConnection struct {
 }
 
 func (bc *baseConnection) Stop() {
+	bc.logger.Debugf("connection stop\n")
 	bc.blockProcessor.removeFromPool()
 }
 
@@ -78,7 +79,7 @@ func (bc *baseConnection) SendConnect(address string) {
 }
 
 func (bc *baseConnection) SendDisconnect(shutdownType uint8) {
-	bc.logger.Debugln("Send disconnect block.")
+	bc.logger.Debugf("Send disconnect block: %v\n", shutdownType)
 	blk := bc.blockProcessor.packDisconnect(bc.connectionID, shutdownType)
 	bc.sendQueue <- blk
 	if shutdownType == block.ShutdownBoth {

--- a/connection/inbound_connection.go
+++ b/connection/inbound_connection.go
@@ -164,6 +164,7 @@ func (c *InboundConnection) Close() error {
 	if c.closed.CAS(false, true) {
 		c.SendDisconnect(block.ShutdownBoth)
 	}
+	c.Stop()
 	return nil
 }
 


### PR DESCRIPTION
对于使用了 reader/writer 抽象之后的双向 io 模型（local -> duplexer -> remote），由于 write 必须在有新的可写入内容写入时才会发生 err，否则就会一直卡住等待远端的 read 能够读进来数据。因此必须支持 shutdown read/shutdown write 才能让整个连接在一方断开时，另一方也能及时断开。

典型现象就是，使用了 rabbit tcp 之后，local process 的 fd 几乎只增不减，很快导致 fd 用尽。

这个 MR 支持了 half open tcp 的情况，可以部分解决这个问题（当然模拟还是不够完善，比如使用 nc 测试，当 remote server 断开之后，local 需要 write 两次才能发现 broken 断开，与直连 write 一次断开仍然有差异）。

此外还顺便修复了一个小 bug：当 inbound closed 变量由 remote 调用 disconnect store true 的时候，没人 stop block processor 导致一直卡死在那资源泄漏。

这个 MR 以最小化改动为原则，只增加了少部分不影响结构的代码来实现上面的内容。
